### PR TITLE
fix: Correct boolean logic for enabling/disabling key owners policy statement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.2
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "this" {
 
   # Key owner - all key operations
   dynamic "statement" {
-    for_each = var.enable_default_policy ? [1] : []
+    for_each = length(var.key_owners) > 0 ? [1] : []
 
     content {
       sid       = "KeyOwner"


### PR DESCRIPTION
## Description
- Correct boolean logic for enabling/disabling key owners policy statement

## Motivation and Context
- Currently, without specifying `key_owners`, users will get a malformed policy document. This looks like a copy+pasta error from the default policy statement block

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
