### PR TITLE
feat: Add support for providing aliases using computed attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,17 @@ module "kms" {
   key_asymmetric_sign_verify_users       = ["arn:aws:iam::012345678901:role/sign-verify-user"]
 
   # Aliases
-  aliases                 = ["one", "foo/bar"]
+  aliases = ["one", "foo/bar"]
+  computed_aliases = {
+    ex = {
+      # Sometimes you want to pass in an upstream attribute as the name and
+      # that conflicts with using `for_each over a `toset()` since the value is not
+      # known until after applying. Instead, we can use `computed_aliases` to work
+      # around this limitation
+      # Reference: https://github.com/hashicorp/terraform/issues/30937
+      name = aws_iam_role.lambda.name
+    }
+  }
   aliases_use_name_prefix = true
 
   # Grants
@@ -154,6 +164,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_kms_alias.computed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_external_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_external_key) | resource |
 | [aws_kms_grant.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_grant) | resource |
@@ -169,6 +180,7 @@ No modules.
 | <a name="input_aliases"></a> [aliases](#input\_aliases) | A list of aliases to create. Note - due to the use of `toset()`, values must be static strings and not computed values | `list(string)` | `[]` | no |
 | <a name="input_aliases_use_name_prefix"></a> [aliases\_use\_name\_prefix](#input\_aliases\_use\_name\_prefix) | Determines whether the alias name is used as a prefix | `bool` | `false` | no |
 | <a name="input_bypass_policy_lockout_safety_check"></a> [bypass\_policy\_lockout\_safety\_check](#input\_bypass\_policy\_lockout\_safety\_check) | A flag to indicate whether to bypass the key policy lockout safety check. Setting this value to true increases the risk that the KMS key becomes unmanageable | `bool` | `null` | no |
+| <a name="input_computed_aliases"></a> [computed\_aliases](#input\_computed\_aliases) | A map of aliases to create. Values provided via the `name` key of the map can be computed from upstream resources | `any` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_external"></a> [create\_external](#input\_create\_external) | Determines whether an external CMK (externally provided material) will be created or a standard CMK (AWS provided material) | `bool` | `false` | no |
 | <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: `SYMMETRIC_DEFAULT`, `RSA_2048`, `RSA_3072`, `RSA_4096`, `HMAC_256`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. Defaults to `SYMMETRIC_DEFAULT` | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -103,17 +103,8 @@ module "kms" {
   key_asymmetric_sign_verify_users       = ["arn:aws:iam::012345678901:role/sign-verify-user"]
 
   # Aliases
-  aliases = ["one", "foo/bar"]
-  computed_aliases = {
-    ex = {
-      # Sometimes you want to pass in an upstream attribute as the name and
-      # that conflicts with using `for_each over a `toset()` since the value is not
-      # known until after applying. Instead, we can use `computed_aliases` to work
-      # around this limitation
-      # Reference: https://github.com/hashicorp/terraform/issues/30937
-      name = aws_iam_role.lambda.name
-    }
-  }
+  aliases                 = ["one", "foo/bar"] # accepts static strings only
+  computed_aliases        = [aws_iam_role.lambda.name]
   aliases_use_name_prefix = true
 
   # Grants
@@ -164,7 +155,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_kms_alias.computed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_external_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_external_key) | resource |
 | [aws_kms_grant.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_grant) | resource |
@@ -180,7 +170,7 @@ No modules.
 | <a name="input_aliases"></a> [aliases](#input\_aliases) | A list of aliases to create. Note - due to the use of `toset()`, values must be static strings and not computed values | `list(string)` | `[]` | no |
 | <a name="input_aliases_use_name_prefix"></a> [aliases\_use\_name\_prefix](#input\_aliases\_use\_name\_prefix) | Determines whether the alias name is used as a prefix | `bool` | `false` | no |
 | <a name="input_bypass_policy_lockout_safety_check"></a> [bypass\_policy\_lockout\_safety\_check](#input\_bypass\_policy\_lockout\_safety\_check) | A flag to indicate whether to bypass the key policy lockout safety check. Setting this value to true increases the risk that the KMS key becomes unmanageable | `bool` | `null` | no |
-| <a name="input_computed_aliases"></a> [computed\_aliases](#input\_computed\_aliases) | A map of aliases to create. Values provided via the `name` key of the map can be computed from upstream resources | `any` | `{}` | no |
+| <a name="input_computed_aliases"></a> [computed\_aliases](#input\_computed\_aliases) | A map of aliases to create. Values provided via the `name` key of the map can be computed from upstream resources | `list(string)` | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_external"></a> [create\_external](#input\_create\_external) | Determines whether an external CMK (externally provided material) will be created or a standard CMK (AWS provided material) | `bool` | `false` | no |
 | <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: `SYMMETRIC_DEFAULT`, `RSA_2048`, `RSA_3072`, `RSA_4096`, `HMAC_256`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. Defaults to `SYMMETRIC_DEFAULT` | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -103,8 +103,17 @@ module "kms" {
   key_asymmetric_sign_verify_users       = ["arn:aws:iam::012345678901:role/sign-verify-user"]
 
   # Aliases
-  aliases                 = ["one", "foo/bar"] # accepts static strings only
-  computed_aliases        = [aws_iam_role.lambda.name]
+  aliases = ["one", "foo/bar"] # accepts static strings only
+  computed_aliases = {
+    ex = {
+      # Sometimes you want to pass in an upstream attribute as the name and
+      # that conflicts with using `for_each over a `toset()` since the value is not
+      # known until after applying. Instead, we can use `computed_aliases` to work
+      # around this limitation
+      # Reference: https://github.com/hashicorp/terraform/issues/30937
+      name = aws_iam_role.lambda.name
+    }
+  }
   aliases_use_name_prefix = true
 
   # Grants
@@ -170,7 +179,7 @@ No modules.
 | <a name="input_aliases"></a> [aliases](#input\_aliases) | A list of aliases to create. Note - due to the use of `toset()`, values must be static strings and not computed values | `list(string)` | `[]` | no |
 | <a name="input_aliases_use_name_prefix"></a> [aliases\_use\_name\_prefix](#input\_aliases\_use\_name\_prefix) | Determines whether the alias name is used as a prefix | `bool` | `false` | no |
 | <a name="input_bypass_policy_lockout_safety_check"></a> [bypass\_policy\_lockout\_safety\_check](#input\_bypass\_policy\_lockout\_safety\_check) | A flag to indicate whether to bypass the key policy lockout safety check. Setting this value to true increases the risk that the KMS key becomes unmanageable | `bool` | `null` | no |
-| <a name="input_computed_aliases"></a> [computed\_aliases](#input\_computed\_aliases) | A map of aliases to create. Values provided via the `name` key of the map can be computed from upstream resources | `list(string)` | `[]` | no |
+| <a name="input_computed_aliases"></a> [computed\_aliases](#input\_computed\_aliases) | A map of aliases to create. Values provided via the `name` key of the map can be computed from upstream resources | `any` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created (affects all resources) | `bool` | `true` | no |
 | <a name="input_create_external"></a> [create\_external](#input\_create\_external) | Determines whether an external CMK (externally provided material) will be created or a standard CMK (AWS provided material) | `bool` | `false` | no |
 | <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: `SYMMETRIC_DEFAULT`, `RSA_2048`, `RSA_3072`, `RSA_4096`, `HMAC_256`, `ECC_NIST_P256`, `ECC_NIST_P384`, `ECC_NIST_P521`, or `ECC_SECG_P256K1`. Defaults to `SYMMETRIC_DEFAULT` | `string` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,8 +42,17 @@ module "kms_complete" {
   key_asymmetric_sign_verify_users       = [local.current_identity]
 
   # Aliases
-  aliases                 = ["one", "foo/bar"] # accepts static strings only
-  computed_aliases        = [aws_iam_role.lambda.name]
+  aliases = ["one", "foo/bar"]
+  computed_aliases = {
+    ex = {
+      # Sometimes you want to pass in an upstream attribute as the name and
+      # that conflicts with using `for_each over a `toset()` since the value is not
+      # known until after applying. Instead, we can use `computed_aliases` to work
+      # around this limitation
+      # Reference: https://github.com/hashicorp/terraform/issues/30937
+      name = aws_iam_role.lambda.name
+    }
+  }
   aliases_use_name_prefix = true
 
   # Grants

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,17 +42,8 @@ module "kms_complete" {
   key_asymmetric_sign_verify_users       = [local.current_identity]
 
   # Aliases
-  aliases = ["one", "foo/bar"]
-  computed_aliases = {
-    ex = {
-      # Sometimes you want to pass in an upstream attribute as the name and
-      # that conflicts with using `for_each over a `toset()` since the value is not
-      # known until after applying. Instead, we can use `computed_aliases` to work
-      # around this limitation
-      # Reference: https://github.com/hashicorp/terraform/issues/30937
-      name = aws_iam_role.lambda.name
-    }
-  }
+  aliases                 = ["one", "foo/bar"] # accepts static strings only
+  computed_aliases        = [aws_iam_role.lambda.name]
   aliases_use_name_prefix = true
 
   # Grants

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,7 +42,17 @@ module "kms_complete" {
   key_asymmetric_sign_verify_users       = [local.current_identity]
 
   # Aliases
-  aliases                 = ["one", "foo/bar"]
+  aliases = ["one", "foo/bar"]
+  computed_aliases = {
+    ex = {
+      # Sometimes you want to pass in an upstream attribute as the name and
+      # that conflicts with using `for_each over a `toset()` since the value is not
+      # known until after applying. Instead, we can use `computed_aliases` to work
+      # around this limitation
+      # Reference: https://github.com/hashicorp/terraform/issues/30937
+      name = aws_iam_role.lambda.name
+    }
+  }
   aliases_use_name_prefix = true
 
   # Grants

--- a/main.tf
+++ b/main.tf
@@ -256,6 +256,14 @@ resource "aws_kms_alias" "this" {
   target_key_id = var.create_external ? aws_kms_external_key.this[0].id : aws_kms_key.this[0].key_id
 }
 
+resource "aws_kms_alias" "computed" {
+  for_each = { for k, v in var.computed_aliases : k => v if var.create }
+
+  name          = var.aliases_use_name_prefix ? null : "alias/${each.value.name}"
+  name_prefix   = var.aliases_use_name_prefix ? "alias/${each.value.name}-" : null
+  target_key_id = var.create_external ? aws_kms_external_key.this[0].id : aws_kms_key.this[0].key_id
+}
+
 ################################################################################
 # Grant
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -248,19 +248,18 @@ data "aws_iam_policy_document" "this" {
 # Alias
 ################################################################################
 
+locals {
+  # TODO - at next breaking change, merge both to use the `computed_alias` approach
+  # under the single varaible `aliases`
+  aliases          = { for k, v in toset(var.aliases) : k => v }
+  computed_aliases = { for i, v in var.computed_aliases : i => v }
+}
+
 resource "aws_kms_alias" "this" {
-  for_each = { for k, v in toset(var.aliases) : k => v if var.create }
+  for_each = { for k, v in merge(local.aliases, local.computed_aliases) : k => v if var.create }
 
   name          = var.aliases_use_name_prefix ? null : "alias/${each.value}"
   name_prefix   = var.aliases_use_name_prefix ? "alias/${each.value}-" : null
-  target_key_id = var.create_external ? aws_kms_external_key.this[0].id : aws_kms_key.this[0].key_id
-}
-
-resource "aws_kms_alias" "computed" {
-  for_each = { for k, v in var.computed_aliases : k => v if var.create }
-
-  name          = var.aliases_use_name_prefix ? null : "alias/${each.value.name}"
-  name_prefix   = var.aliases_use_name_prefix ? "alias/${each.value.name}-" : null
   target_key_id = var.create_external ? aws_kms_external_key.this[0].id : aws_kms_key.this[0].key_id
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,7 +38,7 @@ output "external_key_usage" {
 
 output "aliases" {
   description = "A map of aliases created and their attributes"
-  value       = merge(aws_kms_alias.this, aws_kms_alias.computed)
+  value       = aws_kms_alias.this
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -38,7 +38,7 @@ output "external_key_usage" {
 
 output "aliases" {
   description = "A map of aliases created and their attributes"
-  value       = aws_kms_alias.this
+  value       = merge(aws_kms_alias.this, aws_kms_alias.computed)
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -164,8 +164,8 @@ variable "aliases" {
 
 variable "computed_aliases" {
   description = "A map of aliases to create. Values provided via the `name` key of the map can be computed from upstream resources"
-  type        = any
-  default     = {}
+  type        = list(string)
+  default     = []
 }
 
 variable "aliases_use_name_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -164,8 +164,8 @@ variable "aliases" {
 
 variable "computed_aliases" {
   description = "A map of aliases to create. Values provided via the `name` key of the map can be computed from upstream resources"
-  type        = list(string)
-  default     = []
+  type        = any
+  default     = {}
 }
 
 variable "aliases_use_name_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,12 @@ variable "aliases" {
   default     = []
 }
 
+variable "computed_aliases" {
+  description = "A map of aliases to create. Values provided via the `name` key of the map can be computed from upstream resources"
+  type        = any
+  default     = {}
+}
+
 variable "aliases_use_name_prefix" {
   description = "Determines whether the alias name is used as a prefix"
   type        = bool


### PR DESCRIPTION
## Description
- Add support for providing aliases using computed attributes

## Motivation and Context
- Allow users to provide computed attributes for use as alias values without running into https://github.com/hashicorp/terraform/issues/30937

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
