### PR TITLE
feat: Add support for creating customer managed keys used for Route53 DNSSEC signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | The description of the key as viewed in AWS console | `string` | `null` | no |
 | <a name="input_enable_default_policy"></a> [enable\_default\_policy](#input\_enable\_default\_policy) | Specifies whether to enable the default key policy. Defaults to `true` | `bool` | `true` | no |
 | <a name="input_enable_key_rotation"></a> [enable\_key\_rotation](#input\_enable\_key\_rotation) | Specifies whether key rotation is enabled. Defaults to `true` | `bool` | `true` | no |
+| <a name="input_enable_route53_dnssec"></a> [enable\_route53\_dnssec](#input\_enable\_route53\_dnssec) | Determines whether the KMS policy used for Route53 DNSSEC signing is enabled | `bool` | `false` | no |
 | <a name="input_grants"></a> [grants](#input\_grants) | A map of grant definitions to create | `any` | `{}` | no |
 | <a name="input_is_enabled"></a> [is\_enabled](#input\_is\_enabled) | Specifies whether the key is enabled. Defaults to `true` | `bool` | `null` | no |
 | <a name="input_key_administrators"></a> [key\_administrators](#input\_key\_administrators) | A list of IAM ARNs for [key administrators](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-administrators) | `list(string)` | `[]` | no |
@@ -203,6 +204,7 @@ No modules.
 | <a name="input_multi_region"></a> [multi\_region](#input\_multi\_region) | Indicates whether the KMS key is a multi-Region (`true`) or regional (`false`) key. Defaults to `false` | `bool` | `false` | no |
 | <a name="input_override_policy_documents"></a> [override\_policy\_documents](#input\_override\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank `sid`s will override statements with the same `sid` | `list(string)` | `[]` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | A valid policy JSON document. Although this is a key policy, not an IAM policy, an `aws_iam_policy_document`, in the form that designates a principal, can be used | `string` | `null` | no |
+| <a name="input_route53_dnssec_sources"></a> [route53\_dnssec\_sources](#input\_route53\_dnssec\_sources) | A list of maps containing `account_ids` and Route53 `hosted_zone_arn` that will be allowed to sign DNSSEC records | `list(any)` | `[]` | no |
 | <a name="input_source_policy_documents"></a> [source\_policy\_documents](#input\_source\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | <a name="input_valid_to"></a> [valid\_to](#input\_valid\_to) | Time at which the imported key material expires. When the key material expires, AWS KMS deletes the key material and the CMK becomes unusable. If not specified, key material does not expire | `string` | `null` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -40,6 +40,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_kms_complete"></a> [kms\_complete](#module\_kms\_complete) | ../.. | n/a |
 | <a name="module_kms_default"></a> [kms\_default](#module\_kms\_default) | ../.. | n/a |
 | <a name="module_kms_disabled"></a> [kms\_disabled](#module\_kms\_disabled) | ../.. | n/a |
+| <a name="module_kms_dnssec_signing"></a> [kms\_dnssec\_signing](#module\_kms\_dnssec\_signing) | ../.. | n/a |
 | <a name="module_kms_external"></a> [kms\_external](#module\_kms\_external) | ../.. | n/a |
 
 ## Resources

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -115,6 +115,25 @@ module "kms_external" {
   tags = local.tags
 }
 
+module "kms_dnssec_signing" {
+  source = "../.."
+
+  deletion_window_in_days = 7
+  description             = "CMK for Route53 DNSSEC signing"
+
+  enable_route53_dnssec = true
+  route53_dnssec_sources = [
+    {
+      accounts_ids    = [data.aws_caller_identity.current.account_id] # can ommit if using current account ID which is default
+      hosted_zone_arn = "arn:aws:route53:::hostedzone/*"              # can ommit, this is default value
+    }
+  ]
+
+  aliases = ["route53/dnssec-ex"]
+
+  tags = local.tags
+}
+
 module "kms_default" {
   source = "../.."
 

--- a/main.tf
+++ b/main.tf
@@ -243,6 +243,68 @@ data "aws_iam_policy_document" "this" {
     }
   }
 
+  # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-managing-permissions.html#KMS-key-policy-for-DNSSEC
+  dynamic "statement" {
+    for_each = var.enable_route53_dnssec ? [1] : []
+
+    content {
+      sid = "Route53DnssecService"
+      actions = [
+        "kms:DescribeKey",
+        "kms:GetPublicKey",
+        "kms:Sign",
+      ]
+      resources = ["*"]
+
+      principals {
+        type        = "Service"
+        identifiers = ["dnssec-route53.${data.aws_partition.current.dns_suffix}"]
+      }
+    }
+  }
+
+  # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-managing-permissions.html#KMS-key-policy-for-DNSSEC
+  dynamic "statement" {
+    for_each = var.enable_route53_dnssec ? [1] : []
+
+    content {
+      sid       = "Route53DnssecGrant"
+      actions   = ["kms:CreateGrant"]
+      resources = ["*"]
+
+      principals {
+        type        = "Service"
+        identifiers = ["dnssec-route53.${data.aws_partition.current.dns_suffix}"]
+      }
+
+      condition {
+        test     = "Bool"
+        variable = "kms:GrantIsForAWSResource"
+        values   = ["true"]
+      }
+
+      dynamic "condition" {
+        for_each = var.route53_dnssec_sources
+
+        content {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values   = try(condition.value.account_ids, [data.aws_caller_identity.current.account_id])
+        }
+      }
+
+      dynamic "condition" {
+        for_each = var.route53_dnssec_sources
+
+        content {
+          test     = "ArnLike"
+          variable = "aws:SourceArn"
+          values   = [try(condition.value.hosted_zone_arn, "arn:${data.aws_partition.current.partition}:route53:::hostedzone/*")]
+        }
+      }
+    }
+  }
+
   dynamic "statement" {
     for_each = var.key_statements
 

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,17 @@ variable "override_policy_documents" {
   default     = []
 }
 
+variable "enable_route53_dnssec" {
+  description = "Determines whether the KMS policy used for Route53 DNSSEC signing is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "route53_dnssec_sources" {
+  description = "A list of maps containing `account_ids` and Route53 `hosted_zone_arn` that will be allowed to sign DNSSEC records"
+  type        = list(any)
+  default     = []
+}
 
 ################################################################################
 # Alias


### PR DESCRIPTION
## Description
- Add support for creating customer managed keys used for Route53 DNSSEC signing
	- Reference https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-managing-permissions.html#KMS-key-policy-for-DNSSEC

## Motivation and Context
- Route53 DNSSEC signing requires customer managed keys and this makes that key creation easier and safer (avoids confused deputy problem)

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
