### PR TITLE
docs: Show more accurate usage of Route53 DNSSEC signing KMS key creation example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -118,8 +118,10 @@ module "kms_external" {
 module "kms_dnssec_signing" {
   source = "../.."
 
-  deletion_window_in_days = 7
-  description             = "CMK for Route53 DNSSEC signing"
+  description = "CMK for Route53 DNSSEC signing"
+
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
 
   enable_route53_dnssec = true
   route53_dnssec_sources = [


### PR DESCRIPTION
## Description
- Show more accurate usage of Route53 DNSSEC signing KMS key creation example

## Motivation and Context
- I should have copied the full example I was using the first time; this shows a more accurate example of creating CMKs for Route53 DNSSEC signing

## Breaking Changes
- No

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
