### PR TITLE
fix: Avoid pinned/orphaned IAM role unique IDs in KMS key policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "this" {
       resources = ["*"]
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_owners
         variable = "aws:PrincipalArn"
       }
@@ -150,7 +150,7 @@ data "aws_iam_policy_document" "this" {
       resources = ["*"]
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_administrators
         variable = "aws:PrincipalArn"
       }
@@ -179,7 +179,7 @@ data "aws_iam_policy_document" "this" {
       resources = ["*"]
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_users
         variable = "aws:PrincipalArn"
       }
@@ -212,7 +212,7 @@ data "aws_iam_policy_document" "this" {
       }
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_service_users
         variable = "aws:PrincipalArn"
       }
@@ -241,7 +241,7 @@ data "aws_iam_policy_document" "this" {
       resources = ["*"]
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_service_roles_for_autoscaling
         variable = "aws:PrincipalArn"
       }
@@ -271,7 +271,7 @@ data "aws_iam_policy_document" "this" {
       }
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_service_roles_for_autoscaling
         variable = "aws:PrincipalArn"
       }
@@ -300,7 +300,7 @@ data "aws_iam_policy_document" "this" {
       resources = ["*"]
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_symmetric_encryption_users
         variable = "aws:PrincipalArn"
       }
@@ -326,7 +326,7 @@ data "aws_iam_policy_document" "this" {
       resources = ["*"]
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_hmac_users
         variable = "aws:PrincipalArn"
       }
@@ -354,7 +354,7 @@ data "aws_iam_policy_document" "this" {
       resources = ["*"]
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_asymmetric_public_encryption_users
         variable = "aws:PrincipalArn"
       }
@@ -381,7 +381,7 @@ data "aws_iam_policy_document" "this" {
       resources = ["*"]
 
       condition {
-        test     = "ForAnyValue:ArnLike"
+        test     = "ArnLike"
         values   = var.key_asymmetric_sign_verify_users
         variable = "aws:PrincipalArn"
       }

--- a/main.tf
+++ b/main.tf
@@ -111,9 +111,16 @@ data "aws_iam_policy_document" "this" {
       actions   = ["kms:*"]
       resources = ["*"]
 
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_owners
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
       principals {
-        type        = "AWS"
-        identifiers = var.key_owners
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -142,9 +149,16 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_administrators
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
       principals {
-        type        = "AWS"
-        identifiers = var.key_administrators
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -164,9 +178,16 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_users
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
       principals {
-        type        = "AWS"
-        identifiers = var.key_users
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -184,15 +205,22 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
-      principals {
-        type        = "AWS"
-        identifiers = var.key_service_users
-      }
-
       condition {
         test     = "Bool"
         variable = "kms:GrantIsForAWSResource"
         values   = [true]
+      }
+
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_service_users
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
+      principals {
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -212,9 +240,16 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_service_roles_for_autoscaling
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
       principals {
-        type        = "AWS"
-        identifiers = var.key_service_roles_for_autoscaling
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -229,15 +264,22 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
-      principals {
-        type        = "AWS"
-        identifiers = var.key_service_roles_for_autoscaling
-      }
-
       condition {
         test     = "Bool"
         variable = "kms:GrantIsForAWSResource"
         values   = [true]
+      }
+
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_service_roles_for_autoscaling
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
+      principals {
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -257,9 +299,16 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_symmetric_encryption_users
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
       principals {
-        type        = "AWS"
-        identifiers = var.key_symmetric_encryption_users
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -276,9 +325,16 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_hmac_users
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
       principals {
-        type        = "AWS"
-        identifiers = var.key_hmac_users
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -297,9 +353,16 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_asymmetric_public_encryption_users
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
       principals {
-        type        = "AWS"
-        identifiers = var.key_asymmetric_public_encryption_users
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }
@@ -317,9 +380,16 @@ data "aws_iam_policy_document" "this" {
       ]
       resources = ["*"]
 
+      condition {
+        test     = "ForAnyValue:ArnLike"
+        values   = var.key_asymmetric_sign_verify_users
+        variable = "aws:PrincipalArn"
+      }
+
+      # Required but redundant.
       principals {
-        type        = "AWS"
-        identifiers = var.key_asymmetric_sign_verify_users
+        type        = "*"
+        identifiers = ["*"]
       }
     }
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This replaces all instances of:

```tf
principals {
  type        = "AWS"
  identifiers = <list of IAM role ARNs>
}
```

with the functionally identical, but non-functionally more resilient, alternative:

```tf
condition {
  test     = "ArnLike"
  values   = <list of IAM role ARNs>
  variable = "aws:PrincipalArn"
}

# Required but redundant.
principals {
  type        = "*"
  identifiers = ["*"]
}
```

in the generated KMS key policy.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In many areas around AWS where an IAM role (or indeed any IAM entity) is referenced by ARN, IAM actually replaces the given ARN reference with the IAM entity's underlying [unique identifier](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids) behind the scenes. An example is when referencing an IAM entity as a principal within a resource policy, e.g. KMS key policy.

The [IAM documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user.html#roles-creatingrole-user-cli) states this is to _"mitigate the risk of someone escalating their permissions by removing and recreating the [IAM entity]"_. However, in reality, a) it is a leaky abstraction that violates the [principle of least surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment), i.e. a reference that was originally declared by ARN should always follow the ARN (rather than the thing initially abstracted by it); and b) in practical terms, it's entirely reasonable for the IAM entity to be managed out-of-band with a separate lifecycle (e.g. via a CloudFormation StackSet, or via a separate Terraform workspace, etc.) and there is no particular reason why the lifecycle of the IAM entity should be coupled to the lifecycle of the reference, e.g. no reason why a KMS key policy should be updated whenever the IAM entity is modified (re-created) elsewhere.

Fortunately, in the case of resource policies, there is a solution: the global condition [`aws:PrincipalArn`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalarn) achieves the same functional behaviour as a principal clause, but additionally respects the ARN abstraction layer by not caring about what's underneath it.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

Not a breaking change:

- externally, the module interface (i.e. input and output variables) has not changed; and,
- internally, the new global condition [`aws:PrincipalArn`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principalarn) achieves the same functional behaviour as the old principal clause.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s) - _No interface changes._
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
