### PR TITLE
fix: dynamic condition block for key-statements input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -416,7 +416,7 @@ data "aws_iam_policy_document" "this" {
       }
 
       dynamic "condition" {
-        for_each = try(statement.value.conditions, [])
+        for_each = try(statement.value.condition, [])
 
         content {
           test     = condition.value.test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Fix a dynamic condition block for [key_statements](https://github.com/terraform-aws-modules/terraform-aws-kms#input_key_statements) input.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Latest release doesn't create condition dynamic block as it performs evaluation of incorrect attribute. 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
- No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
