### PR TITLE
Fix for Warning: Reference to undefined provider

### DIFF
--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+  }
 }


### PR DESCRIPTION
## Description

When specifying a provider configuration to wrappers, terraform emits this warnings.

    ╷
    │ Warning: Reference to undefined provider
    │
    │   on terraform.tf line 41, in module
    "main":
    │   41:     aws = aws.primary
    │
    │ There is no explicit declaration for local provider name "aws" in
    module.aws-kms, so
    │ Terraform is assuming you mean to pass a configuration for
    "hashicorp/aws".
    │
    │ If you also control the child module, add a required_providers entry
    named "aws" with the source address "hashicorp/aws".
    │
    │ (and one more similar warning elsewhere)
    ╵


## Motivation and Context

This change reduces the reporting of warnings in terraform. Terraform is extremely fragile and warnings are often a symptom of breakage-to-come, so reducing warnings to an absolutely minimum is a useful goal state.

## Breaking Changes

No known.

## How Has This Been Tested?
- [n/a ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)

    n/a because this is a module-call-site side warning, exhaustively testing all module-call-site's warning would require a stack of infinite size, but we could insist on having a stack of at least two module depth for every module to ensure the "middle depth" example modules produce no warnings.

    - [n/a ] I have tested and validated these changes using one or more of the provided `examples/*` projects
    
- [x] Please describe how you tested your changes

    I have installed this commit to check the terraform warning is no longer emitted
    
         module "main" {
        -  source = "terraform-aws-modules/kms/aws//wrappers"
        +  #source = "terraform-aws-modules/kms/aws//wrappers"
        +  source = "git::https://github.com/dylan-shipwell/terraform-aws-kms//wrappers?ref=5e322b3c8979c2a3b687dabca3d39f0080edf691"
        +
           providers = {
             aws = aws.primary
           }
    
        (terraform (1.1.5) apply no longer emits this warning)
  
