### PR TITLE
feat!: Support `rotation_period_in_days`, AWS Provider v5, Terraform MSV 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.33 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.33 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.49 |
 
 ## Modules
 
@@ -211,6 +211,7 @@ No modules.
 | <a name="input_policy"></a> [policy](#input\_policy) | A valid policy JSON document. Although this is a key policy, not an IAM policy, an `aws_iam_policy_document`, in the form that designates a principal, can be used | `string` | `null` | no |
 | <a name="input_primary_external_key_arn"></a> [primary\_external\_key\_arn](#input\_primary\_external\_key\_arn) | The primary external key arn of a multi-region replica external key | `string` | `null` | no |
 | <a name="input_primary_key_arn"></a> [primary\_key\_arn](#input\_primary\_key\_arn) | The primary key arn of a multi-region replica key | `string` | `null` | no |
+| <a name="input_rotation_period_in_days"></a> [rotation\_period\_in\_days](#input\_rotation\_period\_in\_days) | Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive) | `number` | `null` | no |
 | <a name="input_route53_dnssec_sources"></a> [route53\_dnssec\_sources](#input\_route53\_dnssec\_sources) | A list of maps containing `account_ids` and Route53 `hosted_zone_arn` that will be allowed to sign DNSSEC records | `list(any)` | `[]` | no |
 | <a name="input_source_policy_documents"></a> [source\_policy\_documents](#input\_source\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.49 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,13 +25,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.33 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.49 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.33 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.49 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,7 +24,7 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.49 |
 
 ## Providers

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.33"
+      version = ">= 5.49"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ resource "aws_kms_key" "this" {
   key_usage                          = var.key_usage
   multi_region                       = var.multi_region
   policy                             = coalesce(var.policy, data.aws_iam_policy_document.this[0].json)
+  rotation_period_in_days            = var.rotation_period_in_days
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -182,6 +182,12 @@ variable "route53_dnssec_sources" {
   default     = []
 }
 
+variable "rotation_period_in_days" {
+  description = "Custom period of time between each rotation date. Must be a number between 90 and 2560 (inclusive)"
+  type        = number
+  default     = null
+}
+
 ################################################################################
 # Replica Key
 ################################################################################

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.33"
+      version = ">= 5.49"
     }
   }
 }

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -37,6 +37,7 @@ module "wrapper" {
   policy                                 = try(each.value.policy, var.defaults.policy, null)
   primary_external_key_arn               = try(each.value.primary_external_key_arn, var.defaults.primary_external_key_arn, null)
   primary_key_arn                        = try(each.value.primary_key_arn, var.defaults.primary_key_arn, null)
+  rotation_period_in_days                = try(each.value.rotation_period_in_days, var.defaults.rotation_period_in_days, null)
   route53_dnssec_sources                 = try(each.value.route53_dnssec_sources, var.defaults.route53_dnssec_sources, [])
   source_policy_documents                = try(each.value.source_policy_documents, var.defaults.source_policy_documents, [])
   tags                                   = try(each.value.tags, var.defaults.tags, {})


### PR DESCRIPTION
## Description
- add support for `rotation_period_in_days`
- aws provider version v5
- terraform MSV 1.3

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/37140

## Breaking Changes
- aws provider version v5
- terraform MSV 1.3

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
