### PR TITLE
feat: Grants output marked as sensitive data

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -48,4 +48,5 @@ output "aliases" {
 output "grants" {
   description = "A map of grants created and their attributes"
   value       = aws_kms_grant.this
+  sensitive   = true
 }

--- a/wrappers/outputs.tf
+++ b/wrappers/outputs.tf
@@ -1,5 +1,5 @@
 output "wrapper" {
   description = "Map of outputs of a wrapper."
   value       = module.wrapper
-  # sensitive = false # No sensitive module output found
+  sensitive   = true # At least one sensitive module output (grants) found (requires Terraform 0.14+)
 }


### PR DESCRIPTION
## Description

When using grants for KMS keys, Terraform reports the following: 
```
│ Error: Output refers to sensitive values
│
│   on outputs.tf line 48:
│   48: output "grants" {
```

Therefore, adding the proper sensitive parameter to the grants output. The reason is that the grants expose a token that is considered to be sensitive. 

## Motivation and Context

This is related to this [issue](https://github.com/hashicorp/terraform-provider-aws/issues/36450) that was included in AWS provider version 5.51.0, where the grant_token output is marked as sensitive, and therefore as per Terraform error shows: `To reduce the risk of accidentally exporting sensitive data that was intended to be only internal, Terraform requires that any root module output containing sensitive data be explicitly marked as sensitive, to confirm your intent.`.

## Breaking Changes
No, in previous versions to 5.51.0 it will work fine, but in newer versions it won't.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
